### PR TITLE
palette-dark: fix modal, tiddler-info being white

### DIFF
--- a/themes/notebook/base.tid
+++ b/themes/notebook/base.tid
@@ -17,6 +17,13 @@ type: text/vnd.tiddlywiki
     $text$
   </$reveal>
 \end
+
+/* Modal dialogs */
+
+.tc-modal {
+  border-radius: 6px;
+  overflow: hidden;
+}
   
 /* Top and bottom bars */
 

--- a/themes/notebook/palettes/palette-dark
+++ b/themes/notebook/palettes/palette-dark
@@ -32,10 +32,10 @@ message-border: #111
 message-foreground: #d5e2f1
 modal-backdrop: <<colour foreground>>
 modal-background: <<colour background>>
-modal-border: #999999
-modal-footer-background: #f5f5f5
-modal-footer-border: #dddddd
-modal-header-border: #eeeeee
+modal-border: #778591
+modal-footer-background: #2f343e
+modal-footer-border: #111315
+modal-header-border: #778591
 muted-foreground: #999999
 notification-background: #3a5e39
 notification-border: #192c19

--- a/themes/notebook/palettes/palette-dark
+++ b/themes/notebook/palettes/palette-dark
@@ -85,9 +85,9 @@ tiddler-editor-border-image: #ffffff
 tiddler-editor-border: rgba(255, 255, 255, 0.3)
 tiddler-editor-fields-even: <<colour background>>
 tiddler-editor-fields-odd: #2c323b
-tiddler-info-background: #f8f8f8
-tiddler-info-border: #dddddd
-tiddler-info-tab-background: #f8f8f8
+tiddler-info-background: #2f343e
+tiddler-info-border: #111315
+tiddler-info-tab-background: <<colour primary>>
 tiddler-link-background: <<colour background>>
 tiddler-link-foreground: <<colour primary>>
 tiddler-subtitle-foreground: #aaaaaa


### PR DESCRIPTION
Before:

![awful bright white footer](https://github.com/paul-rouse/Notebook/assets/208340/cf445eb7-dc4b-43a5-91dc-9b87f92eb590)

After:

![dark footer](https://github.com/paul-rouse/Notebook/assets/208340/b86e3a46-9a87-44f7-aa87-2e6baf94f107)

+same with tiddler info